### PR TITLE
Fix account ID param and transfer error handling

### DIFF
--- a/internal/application/service/transaction_service.go
+++ b/internal/application/service/transaction_service.go
@@ -28,11 +28,13 @@ func NewTransactionService(trxRepository repository.TransferRepository, accountR
 
 // Transfer implements usecase.TransactionUseCase.
 func (s *TransactionService) Transfer(ctx context.Context, req *dto.TransferRequest) (*dto.TransferResponse, error) {
-	s.trxRepository.CreateTransfer(ctx, &entity.Transfer{
+	if _, err := s.trxRepository.CreateTransfer(ctx, &entity.Transfer{
 		FromAccountId: req.FromAccountId,
 		ToAccountId:   req.ToAccountId,
 		Amount:        req.Amount,
-	})
+	}); err != nil {
+		return nil, err
+	}
 
 	fromAccount, err := s.accountRepository.GetAccount(ctx, req.FromAccountId)
 	if err != nil {
@@ -85,11 +87,13 @@ func (s *TransactionService) TransferWithTrx(ctx context.Context, req *dto.Trans
 	var rToAccount *entity.Account
 
 	fn := func(store infra_repository.IUnitOfWorkStore) error {
-		store.Transfer().CreateTransfer(ctx, &entity.Transfer{
+		if _, err := store.Transfer().CreateTransfer(ctx, &entity.Transfer{
 			FromAccountId: req.FromAccountId,
 			ToAccountId:   req.ToAccountId,
 			Amount:        req.Amount,
-		})
+		}); err != nil {
+			return err
+		}
 
 		fromAccount, err := store.Account().GetAccount(ctx, req.FromAccountId)
 		if err != nil {

--- a/internal/transport/http/controller/account_controller.go
+++ b/internal/transport/http/controller/account_controller.go
@@ -32,7 +32,7 @@ func NewAccountController(accountService usecase.AccountUseCase) *AccountControl
 //	@Failure		404	{object}	common.Response
 //	@Router			/accounts/{id} [get]
 func (ctrl *AccountController) Get(c *gin.Context) {
-	val := c.Param("account_id")
+	val := c.Param("id")
 	id, err := strconv.Atoi(val)
 	if err != nil {
 		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{


### PR DESCRIPTION
## Summary
- correct `account_id` parameter to `id`
- handle errors when creating transfers

## Testing
- `go vet ./...` *(fails: Forbidden)*
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68413fd2199c832998a5230d8f9bf7fa